### PR TITLE
include common.sh in start

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+. common.sh
+
 docker-compose up -d


### PR DESCRIPTION
This addresses issue #7. Manual testing on Mac OS X now builds all containers defined in the docker compose yml
